### PR TITLE
fix crash when exception message was is null

### DIFF
--- a/silicompressor/src/main/java/com/iceteck/silicompressorr/videocompression/MediaController.java
+++ b/silicompressor/src/main/java/com/iceteck/silicompressorr/videocompression/MediaController.java
@@ -668,7 +668,7 @@ public class MediaController {
                                                 outputSurface.awaitNewImage();
                                             } catch (Exception e) {
                                                 errorWait = true;
-                                                Log.e("tmessages", e.getMessage());
+                                                Log.e("tmessages", ""+e.getMessage());
                                             }
                                             if (!errorWait) {
                                                 if (Build.VERSION.SDK_INT >= 18) {
@@ -710,7 +710,7 @@ public class MediaController {
                             videoStartTime = videoTime;
                         }
                     } catch (Exception e) {
-                        Log.e("tmessages", e.getMessage());
+                        Log.e("tmessages", ""+e.getMessage());
                         error = true;
                     }
 
@@ -738,7 +738,7 @@ public class MediaController {
                 }
             } catch (Exception e) {
                 error = true;
-                Log.e("tmessages", e.getMessage());
+                Log.e("tmessages",""+e.getMessage());
             } finally {
                 if (extractor != null) {
                     extractor.release();
@@ -747,7 +747,7 @@ public class MediaController {
                     try {
                         mediaMuxer.finishMovie(false);
                     } catch (Exception e) {
-                        Log.e("tmessages", e.getMessage());
+                        Log.e("tmessages", ""+e.getMessage());
                     }
                 }
                 Log.e("tmessages", "time = " + (System.currentTimeMillis() - time));
@@ -853,7 +853,7 @@ public class MediaController {
                         th.start();
                         th.join();
                     } catch (Exception e) {
-                        Log.e("tmessages", e.getMessage());
+                        Log.e("tmessages", ""+e.getMessage());
                     }
                 }
             }).start();


### PR DESCRIPTION
- I have exterienced a bug when I want to cancel transcode.
- my code sent thread.interrupt() to the thread that runs transcode. (is there other way?)
- MediaController's catch block does not check null of ex.getMessage().

```
java.lang.NullPointerException: println needs a message
        at android.util.Log.println_native(Native Method)
        at android.util.Log.e(Log.java:253)
        at com.iceteck.silicompressorr.videocompression.MediaController.convertVideo(MediaController.java:750)
        at com.iceteck.silicompressorr.videocompression.MediaController.convertVideo(MediaController.java:285)
        at com.iceteck.silicompressorr.SiliCompressor.compressVideo(SiliCompressor.java:214)
```
